### PR TITLE
fix(plantnet): improve 408 timeout error handling

### DIFF
--- a/src/services/PluginsCommonService.js
+++ b/src/services/PluginsCommonService.js
@@ -119,9 +119,11 @@ export default class PluginsCommonService {
 
     rejectWithIdentifyError(pluginName, step, candidate, err, context) {
         let {status, message, mustBeReported} = err;
-        mustBeReported = isSet(mustBeReported) ? mustBeReported : (!isSet(status) || status !== 503);
+        mustBeReported = isSet(mustBeReported) ? mustBeReported : (!isSet(status) || (status !== 503 && status !== 408));
         let identifyError = `Impossible d'identifier l'image avec ${pluginName}`
-        if (status === 503) {
+        if (status === 408) {
+            identifyError += " le service est indisponible (timeout).";
+        } else if (status === 503) {
             identifyError += " le service est indisponible.";
         }
         let pluginTxtError = `[${step}] ${identifyError}`;

--- a/src/servicesExternal/PlantnetApiService.js
+++ b/src/servicesExternal/PlantnetApiService.js
@@ -142,7 +142,15 @@ export default class PlantnetApiService {
                         let errError = err?.message || err;
                         let errDetails = (res?.text) ? " - details:" + res?.text : "";
                         let errResult = "Pl@ntnet identify error (" + errStatus + ") " + errError;
-                        service.logger.error(errResult + errDetails);
+
+                        // Log as info for service unavailability (408 timeout, 503 unavailable)
+                        if (errStatus === 408 || errStatus === 503) {
+                            const unavailabilityReason = errStatus === 408 ? "timeout" : "service unavailable";
+                            service.logger.info(errResult + errDetails + " (" + unavailabilityReason + ")");
+                        } else {
+                            service.logger.error(errResult + errDetails);
+                        }
+
                         reject({message: errResult, status: errStatus});
                         return;
                     }


### PR DESCRIPTION
fix(plantnet): improve 408 timeout error handling
- Log as info instead of error for 408/503 (temporary unavailability)
- Clear distinction between timeout (408) and service unavailable (503)
- Disable mustBeReported for 408 like for 503
- Explicit user messages with error type mention

Fixes #145