### PR TITLE
fix(ci): re-enable pnpm-audit with prod option (Fix #180)

### DIFF
--- a/.github/agent.md
+++ b/.github/agent.md
@@ -49,7 +49,7 @@ Objectif concis
 ## Workflow LLM
 
 ### Pendant développement
-1. Lire `agent.md` + `.github/issue_*.md` actif
+1. Lire `agent.md` + `.github/agent_pr.md` + `.github/issue_*.md` actif
 2. Travailler sur tâches
 3. **Cocher `- [x]` items complétés DANS le fichier issue**
 4. **Ajouter notes importantes en section "Notes de Dev"** (succinct)

--- a/.github/agent_pr.md
+++ b/.github/agent_pr.md
@@ -1,0 +1,39 @@
+# Workflow Pull Request
+
+## Objectif
+Standardiser creation et mise a jour des PR pour eviter erreurs de shell, body incomplet ou mauvaise base.
+
+## Quand l'utiliser
+- Toute demande de `push + PR`
+- Toute demande d'edition du titre/body d'une PR existante
+
+## Checklist rapide
+1. Verifier branche active (`feature/*`) et remote `origin`.
+2. Verifier l'etat git et le scope des fichiers (`git status`, `git diff`).
+3. Push avec upstream (`git push -u origin <branch>`).
+4. Creer PR avec `gh pr create --base main --head <branch>`.
+5. Utiliser `--body-file` (pas `--body` inline) pour eviter les problemes d'echappement.
+6. Verifier resultat via `gh pr view --json url,title,body,baseRefName,headRefName,state`.
+7. Si body incorrect, corriger avec `gh pr edit --body-file <file>`.
+
+## Templates conseilles
+### Titre
+`type(scope): short description (Fix #<id>)`
+
+### Body
+```markdown
+## What
+- changement 1
+- changement 2
+
+## Why
+- raison principale
+
+Fix #<id>
+```
+
+## Guardrails
+- Ne jamais exposer de token dans les retours utilisateur.
+- Toujours confirmer base/head avant creation PR.
+- Ne jamais lancer commit/push sans validation explicite humaine.
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,19 +62,17 @@ jobs:
           else
             echo "::warning title=ℹ️ 🕸 Outdated Dependencies::Some dependencies are outdated. Please consider updating them."
           fi
-          pnpm audit --prod || echo "::warning title=ℹ️ 'pnpm audit --prod' is not enforced but contains some results : please check it on your own - cf. .github/workflows/main.yml"
 
-### COMMENTED WHILE WAITING FOR # pnpm audit --prod :
-### https://github.com/JamesRobertWiseman/pnpm-audit/issues/10
-##      - name: CHECK - pnpm audit and comment on PR
-##        if: ${{ github.event.pull_request }}
-##        uses: JamesRobertWiseman/pnpm-audit@v3
-##        with:
-##          github_token: ${{ secrets.GITHUB_TOKEN }}
-##          # level: moderate   # 'low'|'moderate'|'high'|'critical'
-##          fails: true # true to fail the build if vulnerabilities are found
-##          single_comment: true # true to only post one comment
-##          inline: true # true to emit audit findings directly in the workflow logs using GitHub annotation syntax
+      - name: CHECK - pnpm audit and comment on PR
+        if: ${{ github.event.pull_request }}
+        uses: JamesRobertWiseman/pnpm-audit@v3.2.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prod: true
+          # level: moderate   # 'low'|'moderate'|'high'|'critical'
+          fails: true # true to fail the build if vulnerabilities are found
+          single_comment: true # true to only post one comment
+          inline: true # true to emit audit findings directly in the workflow logs using GitHub annotation syntax
 
       - name: Run tests
         env:

--- a/agent.md
+++ b/agent.md
@@ -16,7 +16,7 @@ SOLID, KISS, DRY | MCP IntelliJ prioritaire | pnpm only
 
 ## Workflow
 
-1. Lire `agent.md` + `.github/agent.md` + issue active
+1. Lire `agent.md` + `.github/agent.md` + `.github/agent_pr.md` + issue active
 2. Analyser code existant (patterns, conventions)
 3. Appliquer SOLID/KISS
 4. Tests manuels (bot simulation, web UI)


### PR DESCRIPTION
## What
- use `JamesRobertWiseman/pnpm-audit@v3.2.0` (first version supporting `prod` input)
- add `prod: true` to audit action config (prod-only scope on PR)
- keep full audit (dev+prod) in `.github/workflows/audit.yml`
- remove temporary inline `pnpm audit --prod` from outdated check block
- add `.github/agent_pr.md` PR skill (reusable checklist for future PRs)
- reference `agent_pr.md` in `agent.md` and `.github/agent.md` read rituals
## Why
- aligns CI behavior with issue #180
- `@v3` did not support `prod` input — fixed with `@v3.2.0`
Fix #180
