### PR TITLE
feat(#182): improve URL shortener with v.gd fallback and error detection

### DIFF
--- a/src/lib/UrlShortener.js
+++ b/src/lib/UrlShortener.js
@@ -1,24 +1,46 @@
 /**
  * URL Shortener Service
  * 
- * Uses is.gd service for URL shortening
- * Official website: https://is.gd/
- * API documentation: https://is.gd/developers.php
- * 
+ * Multi-provider URL shortening with fallback support
+ *
+ * Providers (in order of preference):
+ * 1. is.gd - Direct 301 redirect, no tracking, free (since 2006)
+ * 2. v.gd - Backup provider with compatible API
+ *
  * Features:
- * - Direct 301 redirect (no intermediate page)
- * - No tracking, no user data collection
- * - Free service with reasonable usage limits
- * - No API key required
- * - Service online since 2006
- * 
+ * - Multiple provider support with automatic failover
+ * - User-Agent header identifying botEnSky
+ * - Improved error logging with status codes and details
+ * - CloudFlare challenge detection
+ * - Fallback to full URL if all providers fail
+ *
+ * Official websites:
+ * - https://is.gd/
+ * - https://v.gd/
  */
 
 import axios from "axios";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+// Get project root directory to read package.json
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '../../');
+
+// Cache package.json version
+let botVersion = '1.0.0'; // fallback
+try {
+    const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8'));
+    botVersion = packageJson.version || botVersion;
+} catch (e) {
+    // Silently fail, use fallback version
+}
 
 /**
- * Shorten URL using is.gd service
- * 
+ * Shorten URL using multiple providers with fallback
+ *
  * @param {Object} logger - Logger instance
  * @param {string} imageUrl - URL to shorten
  * @param {string} text - Text prefix for the shortened URL
@@ -34,18 +56,106 @@ export const buildShortUrlWithText = (logger, imageUrl, text) => {
             return resolve(false);
         }
         
-        // is.gd API - no key required, no intermediate page, direct 301 redirect
-        const apiUrl = `https://is.gd/create.php?format=simple&url=${encodeURIComponent(imageUrl)}`;
-        
-        axios.get(apiUrl, { timeout: 5000 })
-            .then(response => {
-                const shortenUrl = response.data.trim();
-                resolve(`${text}${shortenUrl}`);
-            })
-            .catch(err => {
-                logger.warn(`Unable to use is.gd for this url : ${imageUrl} - details: ${err?.message}`);
-                // Fallback to full URL if shortening fails
-                resolve(`${text}\n${imageUrl}`);
-            });
+        // Shorten with multiple providers in fallback order
+        _shortenWithFallback(logger, imageUrl, 0, text, resolve);
     });
-}
+};
+
+/**
+ * List of URL shortener providers ordered by preference
+ * Each provider object contains:
+ * - name: Provider identifier
+ * - buildUrl: Function to build the API URL
+ * - parseResponse: Function to extract shortened URL from response
+ * - isValidShortUrl: Function to validate the response (optional, checks if URL is valid)
+ *
+ * Providers:
+ * - is.gd: Free, no auth, direct 301 redirect (primary)
+ * - v.gd: Free, no auth, compatible API, also a direct service (fallback)
+ */
+const SHORTENER_PROVIDERS = [
+    {
+        name: 'is.gd',
+        buildUrl: (url) => `https://is.gd/create.php?format=simple&url=${encodeURIComponent(url)}`,
+        parseResponse: (data) => data.trim(),
+        isValidShortUrl: (shortUrl) => shortUrl.startsWith('https://is.gd/'),
+    },
+    {
+        name: 'v.gd',
+        buildUrl: (url) => `https://v.gd/create.php?format=simple&url=${encodeURIComponent(url)}`,
+        parseResponse: (data) => data.trim(),
+        isValidShortUrl: (shortUrl) => shortUrl.startsWith('https://v.gd/'),
+    },
+];
+
+/**
+ * Attempt to shorten URL with a provider and fallback to next if needed
+ *
+ * @private
+ * @param {Object} logger - Logger instance
+ * @param {string} imageUrl - URL to shorten
+ * @param {number} providerIndex - Current provider index
+ * @param {string} text - Text prefix for the shortened URL
+ * @param {Function} resolve - Promise resolve callback
+ */
+const _shortenWithFallback = (logger, imageUrl, providerIndex, text, resolve) => {
+    if (providerIndex >= SHORTENER_PROVIDERS.length) {
+        // All providers exhausted, fallback to full URL
+        logger.info(`URL shortener unavailable for: ${imageUrl} - using full URL instead`);
+        return resolve(`${text}\n${imageUrl}`);
+    }
+
+    const provider = SHORTENER_PROVIDERS[providerIndex];
+    const apiUrl = provider.buildUrl(imageUrl);
+
+    const axiosConfig = {
+        timeout: 5000,
+        headers: {
+            'User-Agent': _buildUserAgent(),
+        },
+    };
+
+    axios.get(apiUrl, axiosConfig)
+        .then(response => {
+            const shortenUrl = provider.parseResponse(response.data);
+
+            // Validate the shortened URL
+            const isValid = provider.isValidShortUrl ? provider.isValidShortUrl(shortenUrl) : shortenUrl.startsWith('https://');
+
+            if (!isValid) {
+                // Looks like an error response (e.g., "Error, database insert failed")
+                logger.warn(`${provider.name} returned error: ${shortenUrl} - trying next provider`);
+                _shortenWithFallback(logger, imageUrl, providerIndex + 1, text, resolve);
+                return;
+            }
+
+            logger.debug(`Successfully shortened URL with ${provider.name}: ${shortenUrl}`);
+            resolve(`${text}${shortenUrl}`);
+        })
+        .catch(err => {
+            const statusCode = err?.response?.status || 'N/A';
+            const isCloudFlareChallenge = err?.response?.headers?.server?.includes('cloudflare') ||
+                                         err?.response?.data?.includes?.('challenge');
+
+            if (isCloudFlareChallenge) {
+                logger.info(`${provider.name} blocked request (CloudFlare challenge) - trying next provider`);
+            } else if (statusCode !== 'N/A') {
+                logger.warn(`${provider.name} returned status ${statusCode} for URL shortening - trying next provider`);
+            } else {
+                logger.warn(`${provider.name} unavailable: ${err?.message} - trying next provider`);
+            }
+
+            // Try next provider
+            _shortenWithFallback(logger, imageUrl, providerIndex + 1, text, resolve);
+        });
+};
+
+/**
+ * Build User-Agent string identifying botEnSky
+ *
+ * @private
+ * @returns {string} User-Agent header value
+ */
+const _buildUserAgent = () => {
+    return `botEnSky/${botVersion} (Bluesky bot; +https://github.com/boly38/botEnSky)`;
+};

--- a/tests/manual/url_shortener/README.md
+++ b/tests/manual/url_shortener/README.md
@@ -1,0 +1,121 @@
+# Tests manuels - URL Shortener
+
+Tests manuels pour diagnostiquer et tester le service de raccourcissement d'URLs avec plusieurs providers.
+
+## Fichiers de test
+
+### 1. `service.js` - Test du service complet
+Test du service `UrlShortener` avec support multi-provider et fallback.
+
+```bash
+node tests/manual/url_shortener/service.js
+```
+
+**Teste:**
+- ✅ Le service `buildShortUrlWithText()` avec fallback multi-provider
+- ✅ Détection du provider réussi (is.gd, v.gd, ou fallback)
+- ✅ Logs d'information pour chaque étape
+
+**Résultats attendus:**
+- Raccourcissement réussi avec is.gd ou v.gd
+- Si tous les providers échouent, fallback vers l'URL complète
+
+---
+
+### 2. `raw_isgd.js` - Test raw is.gd API
+Test direct de l'API is.gd (Node.js HTTPS natif, zéro dépendances).
+
+```bash
+node tests/manual/url_shortener/raw_isgd.js
+```
+
+**Teste:**
+- ✅ Appel brut à is.gd
+- ✅ Réponse HTTP (status, headers, body)
+- ✅ Détection d'erreurs (403 CloudFlare, erreur métier, etc.)
+
+**Cas d'intérêt:**
+- **200 + https://is.gd/xxx** : Provider fonctionne ✅
+- **200 + Error, database insert failed** : Service dégradé (voir ticket #182)
+- **403 Forbidden** : CloudFlare challenge (voir ticket #182)
+
+---
+
+### 3. `raw_vgd.js` - Test raw v.gd API
+Test direct de l'API v.gd (fallback provider, fonctionnalité similaire à is.gd).
+
+```bash
+node tests/manual/url_shortener/raw_vgd.js
+```
+
+**Teste:**
+- ✅ Appel brut à v.gd
+- ✅ Réponse HTTP (status, headers, body)
+- ✅ Détection d'erreurs
+
+**Cas d'intérêt:**
+- **200 + https://v.gd/xxx** : Provider fonctionne ✅
+- **200 + Error** : Erreur métier v.gd
+- **403 Forbidden** : v.gd peut aussi bloquer les requêtes
+
+**Note:** v.gd est un service compatible avec is.gd, avec API similaire. Il peut servir de fallback.
+
+---
+
+## Workflow de diagnostic
+
+### Scenario 1: "Le service ne raccourcit plus les URLs"
+```bash
+# 1. Tester le service complet
+node tests/manual/url_shortener/service.js
+
+# 2. Si fallback: tester is.gd directement
+node tests/manual/url_shortener/raw_isgd.js
+
+# 3. Si is.gd échoue, vérifier v.gd (fallback)
+node tests/manual/url_shortener/raw_vgd.js
+```
+
+### Scenario 2: "Vérifier la résilience multi-provider"
+```bash
+# Tous les tests devraient passer ou fallback correctement
+node tests/manual/url_shortener/service.js
+node tests/manual/url_shortener/raw_isgd.js
+node tests/manual/url_shortener/raw_vgd.js
+```
+
+### Scenario 3: "Déboguer un provider spécifique"
+```bash
+# Tester le provider isolé (ex: v.gd)
+node tests/manual/url_shortener/raw_vgd.js
+
+# Puis vérifier que le service utilise le fallback correctement
+node tests/manual/url_shortener/service.js
+```
+
+---
+
+## Notes
+
+- ✅ Les tests raw utilisent Node.js HTTPS natif (zéro dépendances)
+- ✅ Les tests incluent User-Agent `botEnSky/test` pour éviter les blocages
+- ✅ Timeouts à 5 secondes pour éviter les blocages infinis
+- ⚠️ Les logs du service incluent les codes HTTP et détails pour diagnostic
+
+---
+
+## Providers supportés
+
+| Provider | Endpoint | Type | Notes |
+|----------|----------|------|-------|
+| **is.gd** | `https://is.gd/create.php` | Primaire | Gratuit, depuis 2006, compatible 301 redirect |
+| **v.gd** | `https://v.gd/create.php` | Fallback | Gratuit, API compatible avec is.gd |
+
+---
+
+## Références
+
+- Service: `src/lib/UrlShortener.js`
+- Issue #182: is.gd 403 errors + improvements
+- Providers: is.gd (primaire), v.gd (fallback)
+

--- a/tests/manual/url_shortener/raw_isgd.js
+++ b/tests/manual/url_shortener/raw_isgd.js
@@ -1,0 +1,100 @@
+/**
+ * Test raw is.gd API
+ *
+ * Test direct du provider is.gd (Node.js native HTTPS, zéro dépendances)
+ *
+ * Utilisation:
+ *   node tests/manual/url_shortener/raw_isgd.js
+ */
+
+import https from 'https';
+import { URL } from 'url';
+
+const TEST_URL = 'https://avibase.bsc-eoc.org/species.jsp?lang=EN&avibaseid=0C1EFC9B&sec=flickr';
+
+/**
+ * Fournit une fonction de test brute pour is.gd
+ * @param {string} urlToShorten URL à raccourcir
+ * @returns {Promise<Object>} Réponse avec statusCode, statusMessage, headers, body
+ */
+function fetchIsGd(urlToShorten) {
+  return new Promise((resolve, reject) => {
+    const apiUrl = `https://is.gd/create.php?format=simple&url=${encodeURIComponent(urlToShorten)}`;
+
+    const url = new URL(apiUrl);
+    const options = {
+      hostname: url.hostname,
+      path: url.pathname + url.search,
+      method: 'GET',
+      timeout: 5000,
+      // Add User-Agent to match service behavior
+      headers: {
+        'User-Agent': 'botEnSky/test (Bluesky bot manual test)',
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+          headers: res.headers,
+          body: data.trim(),
+        });
+      });
+    });
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timeout'));
+    });
+
+    req.end();
+  });
+}
+
+async function main() {
+  console.log('🧪 Test raw is.gd API (Node.js native HTTPS)');
+  console.log('=============================================\n');
+  console.log(`URL à raccourcir: ${TEST_URL}\n`);
+
+  try {
+    console.log('🔄 Appel API is.gd...');
+    const response = await fetchIsGd(TEST_URL);
+
+    console.log(`Status HTTP: ${response.statusCode} ${response.statusMessage}`);
+    console.log(`Headers: ${JSON.stringify(response.headers, null, 2)}`);
+    console.log(`Response: ${response.body}\n`);
+
+    if (response.statusCode === 200) {
+      if (response.body.startsWith('https://is.gd/')) {
+        console.log(`✅ Succès - URL raccourcie: ${response.body}`);
+      } else if (response.body.startsWith('Error')) {
+        console.log(`❌ Erreur API: ${response.body}`);
+        console.log('(is.gd retourne 200 mais une erreur métier)');
+      } else {
+        console.log(`⚠️  Réponse inattendue: ${response.body}`);
+      }
+    } else if (response.statusCode === 403) {
+      console.log('❌ Erreur 403 Forbidden (CloudFlare?)');
+      console.log('Recommandation: utiliser le fallback TinyURL');
+    } else {
+      console.log(`❌ Erreur HTTP ${response.statusCode}`);
+    }
+  } catch (error) {
+    console.error(`❌ Requête échouée: ${error.message}`);
+    if (error.message.includes('timeout')) {
+      console.log('Recommandation: vérifier la connectivité réseau');
+    }
+  }
+}
+
+main();
+

--- a/tests/manual/url_shortener/raw_vgd.js
+++ b/tests/manual/url_shortener/raw_vgd.js
@@ -1,0 +1,103 @@
+/**
+ * Test raw v.gd API
+ *
+ * Test direct du provider v.gd (fallback provider pour is.gd)
+ * API: https://v.gd/create.php
+ *
+ * Note: v.gd est un service compatible avec is.gd, API similaire
+ *
+ * Utilisation:
+ *   node tests/manual/url_shortener/raw_vgd.js
+ */
+
+import https from 'https';
+import { URL } from 'url';
+
+const TEST_URL = 'https://avibase.bsc-eoc.org/species.jsp?lang=EN&avibaseid=0C1EFC9B&sec=flickr';
+
+/**
+ * Fournit une fonction de test brute pour v.gd
+ * @param {string} urlToShorten URL à raccourcir
+ * @returns {Promise<Object>} Réponse avec statusCode, statusMessage, headers, body
+ */
+function fetchVgd(urlToShorten) {
+  return new Promise((resolve, reject) => {
+    const apiUrl = `https://v.gd/create.php?format=simple&url=${encodeURIComponent(urlToShorten)}`;
+
+    const url = new URL(apiUrl);
+    const options = {
+      hostname: url.hostname,
+      path: url.pathname + url.search,
+      method: 'GET',
+      timeout: 5000,
+      // Add User-Agent to match service behavior
+      headers: {
+        'User-Agent': 'botEnSky/test (Bluesky bot manual test)',
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+          headers: res.headers,
+          body: data.trim(),
+        });
+      });
+    });
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timeout'));
+    });
+
+    req.end();
+  });
+}
+
+async function main() {
+  console.log('🧪 Test raw v.gd API (Node.js native HTTPS)');
+  console.log('==============================================\n');
+  console.log(`URL à raccourcir: ${TEST_URL}\n`);
+
+  try {
+    console.log('🔄 Appel API v.gd...');
+    const response = await fetchVgd(TEST_URL);
+
+    console.log(`Status HTTP: ${response.statusCode} ${response.statusMessage}`);
+    console.log(`Headers: ${JSON.stringify(response.headers, null, 2)}`);
+    console.log(`Response: ${response.body}\n`);
+
+    if (response.statusCode === 200) {
+      if (response.body.startsWith('https://v.gd/')) {
+        console.log(`✅ Succès - URL raccourcie: ${response.body}`);
+      } else if (response.body.startsWith('Error')) {
+        console.log(`❌ Erreur API: ${response.body}`);
+        console.log('(v.gd retourne 200 mais une erreur métier)');
+      } else {
+        console.log(`⚠️  Réponse inattendue: ${response.body}`);
+      }
+    } else if (response.statusCode === 403) {
+      console.log('❌ Erreur 403 Forbidden');
+      console.log('(v.gd peut aussi bloquer les requêtes sans User-Agent)');
+    } else {
+      console.log(`❌ Erreur HTTP ${response.statusCode}`);
+    }
+  } catch (error) {
+    console.error(`❌ Requête échouée: ${error.message}`);
+    if (error.message.includes('timeout')) {
+      console.log('Recommandation: vérifier la connectivité réseau');
+    }
+  }
+}
+
+main();
+

--- a/tests/manual/url_shortener/service.js
+++ b/tests/manual/url_shortener/service.js
@@ -1,0 +1,65 @@
+/**
+ * Test manuel du service UrlShortener
+ *
+ * Teste le service complet avec fallback multi-providers
+ *
+ * Utilisation:
+ *   node tests/manual/url_shortener/service.js
+ */
+
+import { buildShortUrlWithText } from '../../../src/lib/UrlShortener.js';
+
+const TEST_URLS = [
+  'https://avibase.bsc-eoc.org/species.jsp?lang=EN&avibaseid=0C1EFC9B&sec=flickr',
+  'https://unsplash.com/collections/1395868',
+  'https://example.com/very/long/url/that/needs/shortening',
+];
+
+const logger = {
+  debug: (...args) => console.log('[DEBUG]', ...args),
+  info: (...args) => console.log('[INFO] ', ...args),
+  warn: (...args) => console.warn('[WARN] ', ...args),
+  error: (...args) => console.error('[ERROR]', ...args),
+};
+
+async function testUrlShortenerService() {
+  console.log('🧪 Test du service UrlShortener (multi-provider)');
+  console.log('================================================\n');
+
+  for (const testUrl of TEST_URLS) {
+    console.log(`URL: ${testUrl}`);
+
+    try {
+      const prefix = 'Lien court: ';
+      const result = await buildShortUrlWithText(logger, testUrl, prefix);
+
+      console.log(`Résultat: ${result}`);
+
+      // Analyse du résultat
+      const shortPart = typeof result === 'string' ? result.replace(prefix, '').trim() : '';
+
+      if (shortPart.startsWith('https://')) {
+        if (shortPart.startsWith('https://is.gd/') || shortPart.startsWith('https://v.gd/')) {
+          console.log('✅ Raccourcissement OK (provider réussi).\n');
+        } else if (shortPart === testUrl) {
+          console.log('⚠️  Fallback détecté: tous les providers indisponibles.\n');
+        } else {
+          console.log(`✅ Raccourcissement via provider alternatif.\n`);
+        }
+      } else {
+        console.log('❌ Résultat invalide détecté.\n');
+      }
+    } catch (error) {
+      console.error(`❌ Erreur lors du raccourcissement: ${error.message}\n`);
+    }
+  }
+
+  console.log('\n================================================');
+  console.log('Résumé: Service testé avec tous les providers disponibles');
+}
+
+testUrlShortenerService().catch((error) => {
+  console.error('Erreur pendant le test manuel:', error);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
## What

- Improve URL shortener service with v.gd fallback provider (alternative to is.gd)
- Add response validation to detect API errors (e.g., HTTP 200 + "Error, database insert failed")
- Add User-Agent header identifying botEnSky version in all HTTP requests
- Improve error logging with status codes and CloudFlare challenge detection
- Add INFO log when all shorteners are unavailable (falls back to full URL)
- Make SHORTENER_PROVIDERS array extensible for future providers

## Why

Issue #182 reports is.gd returning:
- 403 Forbidden (CloudFlare challenges)
- 200 + "Error, database insert failed" (service degradation)

Solution:
- Detect these error cases and failover to v.gd
- If all providers fail, use full URL instead of silent fallback
- Better diagnostics via improved logging

## Testing

- ✅ Manual test `tests/manual/url_shortener/service.js` - Service with fallback
- ✅ Manual test `tests/manual/url_shortener/raw_isgd.js` - Test is.gd directly
- ✅ Manual test `tests/manual/url_shortener/raw_vgd.js` - Test v.gd directly
- ✅ All existing tests pass (mocha)
- ✅ No regressions observed

## Technical Details

**Providers:**
1. is.gd (primary) - Direct 301 redirect, free, no auth, since 2006
2. v.gd (fallback) - Compatible API with is.gd, also direct redirect

**Error Handling:**
- HTTP errors → try next provider
- CloudFlare challenges → detected and logged as INFO
- 200 + error payload → detected and tries next provider
- All providers exhausted → fallback to full URL

Fix #182

