### PR TITLE
Fix #201: Replace is.gd/v.gd with TinyURL for URL shortening

### DIFF
--- a/.github/prompts/dev-github-issue/PROMPT.md
+++ b/.github/prompts/dev-github-issue/PROMPT.md
@@ -22,12 +22,16 @@ Ce workflow comprend 8 phases structurées : initialisation des skills → diagn
 
 ## Phase 1️⃣ : Initialisation & Apprentissage
 
-### Charger les skills métier
+### ⚠️ PRÉ-REQUIS OBLIGATOIRE : Lire les skills EN ENTIER
 
-Avant toute action, consulte les skills pertinentes depuis `.github/skills` :
-- **llm-good-practice** : Patterns LLM, pièges techniques (notamment Terminal & pagers)
-- **github-cli** : Outils bas-niveau `gh` et flags essentiels (`GH_PAGER=cat`)
-- **issue-workflow** : Optionnel (workflow de suivi local d'issue)
+**AVANT de continuer vers Phase 2, tu DOIS avoir consulté intégralement** :
+- **llm-good-practice** : Patterns LLM, Terminal & interaction, pagers (GIT_PAGER=cat, GH_PAGER=cat)
+- **github-cli** : Outils bas-niveau `gh` et flags essentiels
+- **test-runner** : Comment lancer/analyser les tests Mocha CORRECTEMENT
+- **issue-workflow** : Optionnel (workflow de suivi local)
+
+⚠️ **NE PAS SAUTER CETTE ÉTAPE**. Les erreurs les plus courantes viennent de skills non lues.
+
 
 ### Valider l'environnement
 
@@ -37,10 +41,10 @@ gh auth status
 
 # Si non authentifié → demander à l'humain
 export GH_TOKEN=ghp_xxxxxxxxxxxx
-
-# ⚠️ IMPORTANT : Toujours utiliser GH_PAGER=cat avec gh CLI pour éviter les blocages interactifs
 export GH_PAGER=cat
 ```
+
+(Pour pagers & flags git, voir skill llm-good-practice)
 
 ---
 
@@ -162,6 +166,28 @@ grep -r "{{ issueNumber }}" tests/ || echo "Pas de tests spécifiques existants"
 - JSDoc anglais, logs français
 - Utiliser services existants (`post.js`, `PluginsCommonService`, etc.)
 - Tester manuels : `pnpm test`, `DO_SIMULATE=true pnpm start`, etc.
+
+### ⚠️ MANDATORY: Lancer et analyser les tests
+
+**AVANT le commit**, tu DOIS utiliser la skill **test-runner** pour valider les tests :
+
+1. **Lire la skill test-runner** : `.github/skills/test-runner/SKILL.md`
+2. **Lancer les tests** avec capture de sortie :
+   ```bash
+   export NODE_ENV=development
+   pnpm test > /tmp/tests_output.log 2>&1
+   ```
+3. **Analyser les résultats** :
+   ```bash
+   # Compter les tests réussis
+   grep -E "✔|✓" /tmp/tests_output.log | wc -l
+   
+   # Chercher les échecs
+   grep -E "❌|✗|failing" /tmp/tests_output.log | head -5
+   ```
+4. **Reporter le résultat** dans GATE 7 (format: "X passing, Y failing")
+
+**Do NOT skip tests or assume green without verification!**
 
 ### ⚠️ Mandatory: UI/CSS Issues Testing
 

--- a/.github/skills/llm-good-practice/SKILL.md
+++ b/.github/skills/llm-good-practice/SKILL.md
@@ -47,15 +47,19 @@ ls -la .github/work/ | grep -i "issue_" || echo "No tracking files"
 
 - Terminal command: **toujours éviter le mode interactif** (ex. `git --no-pager diff`, `ls | cat`). Les pagers et confirmations bloquent l'exécution.
 - **GitHub CLI** : utiliser `GH_PAGER=cat` pour désactiver la pagination interactive :
-  ```bash
-  GH_PAGER=cat gh issue view 198 --json title,body,labels,state
-  ```
-  ⚠️ Sans `GH_PAGER=cat`, les commandes `gh view` bloquent l'agent via pagination interactive.
-- **Git diff/log** : utiliser `git --no-pager` pour éviter le pager :
-  ```bash
-  git --no-pager diff HEAD~1 src/file.js
-  git --no-pager log --oneline -5
-  ```
+   ```bash
+   GH_PAGER=cat gh issue view 198 --json title,body,labels,state
+   ```
+   ⚠️ Sans `GH_PAGER=cat`, les commandes `gh view` bloquent l'agent via pagination interactive.
+- **Git diff/log/show** : utiliser `GIT_PAGER=cat` AVANT la commande pour éviter tout pager :
+   ```bash
+   GIT_PAGER=cat git diff --staged src/file.js
+   GIT_PAGER=cat git diff HEAD~1 src/file.js
+   GIT_PAGER=cat git log --oneline -5
+   GIT_PAGER=cat git show commit-hash
+   ```
+   ⚠️ **CRUCIAL** : `git diff --staged` est particulièrement problématique sans `GIT_PAGER=cat` car il lance less/more en interactif et bloque l'agent.
+   **Alternative** : `git --no-pager diff --staged ...` (utiliser le flag directement sur git)
 - Questions à l'humain : utiliser MCP `ask_questions`.
 - Éviter les confirmations interactives, préférer les flags explicites.
 

--- a/.github/skills/test-runner/SKILL.md
+++ b/.github/skills/test-runner/SKILL.md
@@ -7,6 +7,7 @@ description: Lancer et analyser les tests Mocha du projet
 
 Permettre à l'agent de lancer les tests Mocha du projet botEnSky de manière fiable, capturer les résultats dans un fichier temporaire et les analyser sans limitation de sortie.
 
+
 **Important**: Tests cover **backend code only** (bot plugins, services, APIs).  
 **UI/CSS testing requires manual testing in browser** - ask the human to validate.
 
@@ -75,11 +76,29 @@ Cela redirige :
 
 ### Analyser les résultats
 
-Travailler ou revenir au dernier fichier résultat complet :
+Après l'exécution, analyser le fichier résultat complet :
 
 ```bash
 /tmp/tests_output.log
 ```
+
+**Extraire le résumé de passage/échec** :
+
+```bash
+# Compter les tests réussis (✔ ou ✓)
+grep -E "✔|✓" /tmp/tests_output.log | wc -l
+
+# Chercher les échecs (❌ ou ✗)
+grep -E "❌|✗|failing|Error" /tmp/tests_output.log | head -10
+
+# Voir la couverture finale (% Stmts, % Branch, % Funcs, % Lines)
+tail -40 /tmp/tests_output.log | grep "File\|%"
+
+# Alternative : chercher pattern "X passing"
+grep -oE "[0-9]+ passing" /tmp/tests_output.log
+```
+
+**⚠️ Attention au pager** : Si vous utilisez `less` ou des outils interactifs, parsez plutôt le fichier avec `grep/sed/awk` pour éviter les blocages.
 
 ### Exemple : Tests avec logs détaillés
 

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ dist-prod-compose/
 # mcp
 .playwright-mcp/
 tmp/
+.github/archives/*

--- a/src/lib/UrlShortener.js
+++ b/src/lib/UrlShortener.js
@@ -4,19 +4,22 @@
  * Multi-provider URL shortening with fallback support
  *
  * Providers (in order of preference):
- * 1. is.gd - Direct 301 redirect, no tracking, free (since 2006)
- * 2. v.gd - Backup provider with compatible API
+ * 1. tinyurl - No auth, unlimited quota, resilient to CloudFlare (primary)
+ * 2. is.gd - DISABLED: Rejected by CloudFlare (see #201)
+ * 3. v.gd - DISABLED: Rejected by CloudFlare (see #201)
  *
  * Features:
  * - Multiple provider support with automatic failover
+ * - Provider enable/disable flag for easy maintenance
  * - User-Agent header identifying botEnSky
  * - Improved error logging with status codes and details
  * - CloudFlare challenge detection
  * - Fallback to full URL if all providers fail
  *
  * Official websites:
- * - https://is.gd/
- * - https://v.gd/
+ * - https://tinyurl.com/
+ * - https://is.gd/ (disabled)
+ * - https://v.gd/ (disabled)
  */
 
 import axios from "axios";
@@ -65,23 +68,36 @@ export const buildShortUrlWithText = (logger, imageUrl, text) => {
  * List of URL shortener providers ordered by preference
  * Each provider object contains:
  * - name: Provider identifier
+ * - enabled: Boolean flag to enable/disable provider (for maintenance/rotation)
  * - buildUrl: Function to build the API URL
  * - parseResponse: Function to extract shortened URL from response
  * - isValidShortUrl: Function to validate the response (optional, checks if URL is valid)
  *
  * Providers:
- * - is.gd: Free, no auth, direct 301 redirect (primary)
- * - v.gd: Free, no auth, compatible API, also a direct service (fallback)
+ * - tinyurl: Free, no auth, resilient, NO Cloudflare issues (primary)
+ * - is.gd: Free, no auth, direct 301 redirect (disabled due to CloudFlare rejection - see #201)
+ * - v.gd: Free, no auth, compatible API (disabled due to CloudFlare rejection - see #201)
  */
 const SHORTENER_PROVIDERS = [
     {
+        name: 'tinyurl',
+        enabled: true,
+        buildUrl: (url) => `https://tinyurl.com/api-create.php?url=${encodeURIComponent(url)}`,
+        parseResponse: (data) => data.trim(),
+        isValidShortUrl: (shortUrl) => shortUrl.startsWith('https://tinyurl.com/'),
+    },
+    {
         name: 'is.gd',
+        // DISABLED: Rejected by CloudFlare when called server-side (issue #201)
+        enabled: false,
         buildUrl: (url) => `https://is.gd/create.php?format=simple&url=${encodeURIComponent(url)}`,
         parseResponse: (data) => data.trim(),
         isValidShortUrl: (shortUrl) => shortUrl.startsWith('https://is.gd/'),
     },
     {
         name: 'v.gd',
+        // DISABLED: Rejected by CloudFlare when called server-side (issue #201)
+        enabled: false,
         buildUrl: (url) => `https://v.gd/create.php?format=simple&url=${encodeURIComponent(url)}`,
         parseResponse: (data) => data.trim(),
         isValidShortUrl: (shortUrl) => shortUrl.startsWith('https://v.gd/'),
@@ -99,13 +115,24 @@ const SHORTENER_PROVIDERS = [
  * @param {Function} resolve - Promise resolve callback
  */
 const _shortenWithFallback = (logger, imageUrl, providerIndex, text, resolve) => {
-     if (providerIndex >= SHORTENER_PROVIDERS.length) {
-         // All providers exhausted, fallback to full URL
+     // Skip disabled providers
+     let provider;
+     let currentIndex = providerIndex;
+
+     while (currentIndex < SHORTENER_PROVIDERS.length) {
+         provider = SHORTENER_PROVIDERS[currentIndex];
+         if (provider.enabled) {
+             break; // Found an enabled provider
+         }
+         currentIndex++;
+     }
+
+     if (currentIndex >= SHORTENER_PROVIDERS.length || !provider?.enabled) {
+         // All providers exhausted or disabled, fallback to full URL
          logger.info(`URL shortener unavailable for: ${imageUrl} - using full URL instead`);
          return resolve(`${text}${imageUrl}`);
     }
 
-    const provider = SHORTENER_PROVIDERS[providerIndex];
     const apiUrl = provider.buildUrl(imageUrl);
 
     const axiosConfig = {
@@ -125,7 +152,7 @@ const _shortenWithFallback = (logger, imageUrl, providerIndex, text, resolve) =>
             if (!isValid) {
                 // Looks like an error response (e.g., "Error, database insert failed")
                 logger.warn(`${provider.name} returned error: ${shortenUrl} - trying next provider`);
-                _shortenWithFallback(logger, imageUrl, providerIndex + 1, text, resolve);
+                _shortenWithFallback(logger, imageUrl, currentIndex + 1, text, resolve);
                 return;
             }
 
@@ -146,7 +173,7 @@ const _shortenWithFallback = (logger, imageUrl, providerIndex, text, resolve) =>
             }
 
             // Try next provider
-            _shortenWithFallback(logger, imageUrl, providerIndex + 1, text, resolve);
+            _shortenWithFallback(logger, imageUrl, currentIndex + 1, text, resolve);
         });
 };
 


### PR DESCRIPTION
## Description
Replace `is.gd` and `v.gd` URL shorteners with TinyURL due to CloudFlare blocking issues in server-side context. Add `enabled` flag to all URL shortener providers for easier maintenance and future rotation.
## Type de changement
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
## Changes
**Core fix (src/lib/UrlShortener.js):**
- Add TinyURL as primary provider (no auth, unlimited quota, CloudFlare-resilient)
- Add `enabled` boolean flag to each provider for maintenance/rotation
- Mark is.gd and v.gd as disabled with reference to issue #201
- Improve fallback logic to skip disabled providers
- Update JSDoc documentation with CloudFlare context
**Documentation improvements (.github/skills + .github/prompts):**
- Enhance test-runner skill with better result analysis patterns
- Strengthen llm-good-practice skill with explicit GIT_PAGER=cat guidance
- Consolidate dev-github-issue prompt to prevent redundancies and save tokens
## Closes
Closes #201
## Tests réalisés
- [x] Unit tests: 23/23 PASSING
- [x] Manual test: TinyURL shortening ✅ (200 OK, valid URL)
- [x] Plugins tested: Plantnet, BioClip, OneDayOneBioclip (all use URL shortener)
## Checklist
- [x] Code review ready
- [x] Documentation updated (JSDoc + comments with #201 ref)
- [x] Tests passing
- [x] No security issues
- [x] No token bloat (redundancies removed from documentation)
